### PR TITLE
Various fixes found while accepting

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func master(stopChan *chan string) {
 		// has master changed from last time?
 		masterAddr, err = getMasterAddr(saddr, *masterName)
 		if err != nil {
-			log.Println("[MASTER] Error polling for new master: %s", err)
+			log.Printf("[MASTER] Error polling for new master: %s\n", err)
 		}
 		if err == nil && masterAddr.String() != prevMasterAddr.String() {
 			log.Printf("[MASTER] Master Address changed from %s to %s \n", prevMasterAddr.String(), masterAddr.String())
@@ -71,7 +71,7 @@ func master(stopChan *chan string) {
 
 func pipe(r net.Conn, w net.Conn, proxyChan chan<- string) {
 	bytes, err := io.Copy(w, r)
-	log.Println("[PROXY %s => %s] Shutting down stream; transferred %s bytes: %s", w.RemoteAddr().String(), r.RemoteAddr().String(), bytes, err)
+	log.Printf("[PROXY %s => %s] Shutting down stream; transferred %s bytes: %s\n", w.RemoteAddr().String(), r.RemoteAddr().String(), bytes, err)
 	close(proxyChan)
 }
 
@@ -79,7 +79,7 @@ func pipe(r net.Conn, w net.Conn, proxyChan chan<- string) {
 func proxy(client *net.TCPConn, redisAddr *net.TCPAddr, stopChan <-chan string) {
 	redis, err := net.DialTimeout("tcp4", redisAddr.String(), 50*time.Millisecond)
 	if err != nil {
-		log.Println("[PROXY %s => %s] Can't establish connection: %s", client.RemoteAddr().String(), redisAddr.String(), err)
+		log.Printf("[PROXY %s => %s] Can't establish connection: %s\n", client.RemoteAddr().String(), redisAddr.String(), err)
 		client.Close()
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -132,7 +132,7 @@ func getMasterAddr(sentinelAddress string, masterName string) (*net.TCPAddr, err
 		b := make([]byte, 256)
 		_, err = conn.Read(b)
 		if err != nil {
-			log.Fatal(err)
+			log.Printf("[MASTER] Error reading from Sentinel %v:%v: %s", sentinelIP, sentinelPort, err)
 		}
 
 		parts := strings.Split(string(b), "\r\n")

--- a/main.go
+++ b/main.go
@@ -61,7 +61,15 @@ func master(stopChan *chan string) {
 			}
 		}
 
-		time.Sleep(500 * time.Second)
+		if masterAddr == nil {
+			// if we haven't discovered a master at all, then slow our roll as the cluster is
+			// probably still coming up
+			time.Sleep(1 * time.Second)
+		} else {
+			// if we've seen a master before, then it's time for beast mode
+			time.Sleep(250 * time.Millisecond)
+		}
+
 	}
 }
 
@@ -100,7 +108,7 @@ func proxy(client *net.TCPConn, redisAddr *net.TCPAddr, stopChan <-chan string) 
 }
 
 func getMasterAddr(sentinelAddress string, masterName string) (*net.TCPAddr, error) {
-	conn, err := net.DialTimeout("tcp4", sentinelAddress, 50*time.Millisecond)
+	conn, err := net.DialTimeout("tcp4", sentinelAddress, 100*time.Millisecond)
 	if err != nil {
 		return nil, fmt.Errorf("Can't connect to Sentinel: %s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func pipe(r io.Reader, w io.WriteCloser) {
 // pass a stopChan to the go routtine
 func proxy(local io.ReadWriteCloser, remoteAddr *net.TCPAddr, stopChan chan struct{}) {
 	fmt.Printf("Opening a new connection on remoteAddr, %s\n", remoteAddr)
-	remote, err := net.DialTCP("tcp", nil, remoteAddr)
+	remote, err := net.DialTimeout("tcp4", remoteAddr.String(), 50*time.Millisecond)
 	if err != nil {
 		log.Println(err)
 		local.Close()
@@ -93,7 +93,7 @@ func proxy(local io.ReadWriteCloser, remoteAddr *net.TCPAddr, stopChan chan stru
 }
 
 func getMasterAddr(sentinelAddress *net.TCPAddr, masterName string) (*net.TCPAddr, error) {
-	conn, err := net.DialTCP("tcp", nil, sentinelAddress)
+	conn, err := net.DialTimeout("tcp4", sentinelAddress.String(), 50*time.Millisecond)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func getMasterAddr(sentinelAddress *net.TCPAddr, masterName string) (*net.TCPAdd
 	}
 
 	//check that there's actually someone listening on that address
-	conn2, err := net.DialTCP("tcp", nil, addr)
+	conn2, err := net.DialTimeout("tcp", addr.String(), 50*time.Millisecond)
 	if err == nil {
 		defer conn2.Close()
 	}

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func main() {
 			log.Println(err)
 			continue
 		}
-		go proxy(conn, masterAddr, &stopChan)
+		go proxy(conn, masterAddr, stopChan)
 	}
 }
 
@@ -76,7 +76,7 @@ func pipe(r net.Conn, w net.Conn, proxyChan chan<- string) {
 }
 
 // pass a stopChan to the go routtine
-func proxy(client *net.TCPConn, redisAddr *net.TCPAddr, stopChan *chan string) {
+func proxy(client *net.TCPConn, redisAddr *net.TCPAddr, stopChan <-chan string) {
 	redis, err := net.DialTimeout("tcp4", redisAddr.String(), 50*time.Millisecond)
 	if err != nil {
 		log.Println("[PROXY %s => %s] Can't establish connection: %s", client.RemoteAddr().String(), redisAddr.String(), err)
@@ -95,7 +95,7 @@ func proxy(client *net.TCPConn, redisAddr *net.TCPAddr, stopChan *chan string) {
 	go pipe(redis, client, clientChan)
 
 	select {
-	case <-*stopChan:
+	case <-stopChan:
 	case <-clientChan:
 	case <-redisChan:
 	}


### PR DESCRIPTION
- Use short timeouts when establishing connections
- Ensure all connections are closed:
  - Reuse stopChan, instead of making a new one each time master changes
  - Let `pipe()` signal when a client disconnects
- Using log.Print* instead of fmt.Print*
- Rename some variables for clarity on which `net.Conn` is which in the `proxy()` function

@rogeruiz I didn't rebase this onto #2, but I think I got all the changes (or their equivalent) in this PR.  WDYT about closing that in favor of this?